### PR TITLE
Fix turn regeneration to account for per-player elapsed time

### DIFF
--- a/Stellar-Dominion/src/Game/TurnProcessor.php
+++ b/Stellar-Dominion/src/Game/TurnProcessor.php
@@ -99,7 +99,7 @@ if ($result) {
                         credits = credits + ?,
                         deposits_today = GREATEST(0, deposits_today - ?),
                         last_updated = ?,
-                        last_deposit_timestamp = IF(? > 0, NOW(), last_deposit_timestamp)
+                        last_deposit_timestamp = IF(? > 0, ?, last_deposit_timestamp)
                    WHERE id = ?";
     $stmt_update = mysqli_prepare($link, $sql_update);
     if (!$stmt_update) {
@@ -118,17 +118,19 @@ if ($result) {
     $bind_deposits     = 0;     // deposits_granted
     $bind_now_str      = '';
     $bind_deposits_ok  = 0;     // same as deposits_granted for IF()
+    $bind_deposit_ts   = gmdate('Y-m-d H:i:s');
     $bind_user_id      = 0;
 
     mysqli_stmt_bind_param(
         $stmt_update,
-        "iiiisii",
+        "iiiisisi",
         $bind_attack_turns,
         $bind_citizens,
         $bind_credits,
         $bind_deposits,
         $bind_now_str,
         $bind_deposits_ok,
+        $bind_deposit_ts,
         $bind_user_id
     );
 
@@ -140,9 +142,11 @@ if ($result) {
         $deposits_granted = 0;
         $deposits_today   = (int)$user['deposits_today'];
 
+        $last_deposit_ts_value = null;
         if ($deposits_today > 0 && !empty($user['last_deposit_timestamp'])) {
             $last_dep_ts = strtotime($user['last_deposit_timestamp'] . ' UTC');
             if ($last_dep_ts !== false) {
+                $last_deposit_ts_value = $last_dep_ts;
                 $seconds_since_last_deposit = $current_ts - $last_dep_ts;
                 if ($seconds_since_last_deposit >= 21600) { // 6 hours
                     $deposits_to_grant = intdiv($seconds_since_last_deposit, 21600);
@@ -238,6 +242,16 @@ if ($result) {
 
         $bind_now_str      = gmdate('Y-m-d H:i:s', $next_last_updated_ts);
         $bind_deposits_ok  = (int)$deposits_granted;
+        if ($deposits_granted > 0) {
+            if ($last_deposit_ts_value !== null) {
+                $next_last_deposit_ts = $last_deposit_ts_value + ($deposits_granted * 21600);
+            } else {
+                $next_last_deposit_ts = $current_ts;
+            }
+            $bind_deposit_ts = gmdate('Y-m-d H:i:s', $next_last_deposit_ts);
+        } else {
+            $bind_deposit_ts = $user['last_deposit_timestamp'] ?? gmdate('Y-m-d H:i:s', $current_ts);
+        }
         $bind_user_id      = $uid;
 
         if (mysqli_stmt_execute($stmt_update)) {

--- a/Stellar-Dominion/src/Game/TurnProcessor.php
+++ b/Stellar-Dominion/src/Game/TurnProcessor.php
@@ -132,10 +132,9 @@ if ($result) {
         $bind_user_id
     );
 
-    $now_ts = time(); // single snapshot for this cron pass
-
     while ($user = mysqli_fetch_assoc($result)) {
         $uid = (int)$user['id'];
+        $current_ts = time();
 
         // -------- Deposit regeneration (fast integer math) --------
         $deposits_granted = 0;
@@ -144,9 +143,9 @@ if ($result) {
         if ($deposits_today > 0 && !empty($user['last_deposit_timestamp'])) {
             $last_dep_ts = strtotime($user['last_deposit_timestamp'] . ' UTC');
             if ($last_dep_ts !== false) {
-                $hours_since_last_deposit = ($now_ts - $last_dep_ts) / 3600;
-                if ($hours_since_last_deposit >= 6) {
-                    $deposits_to_grant = (int)floor($hours_since_last_deposit / 6);
+                $seconds_since_last_deposit = $current_ts - $last_dep_ts;
+                if ($seconds_since_last_deposit >= 21600) { // 6 hours
+                    $deposits_to_grant = intdiv($seconds_since_last_deposit, 21600);
                     $deposits_granted  = min($deposits_today, $deposits_to_grant);
                 }
             } else {
@@ -160,8 +159,10 @@ if ($result) {
         if ($last_upd_ts === false) {
             write_log("WARN: bad last_updated for user {$uid}, value='{$user['last_updated']}'");
         } else {
-            $minutes_since_last_update = ($now_ts - $last_upd_ts) / 60;
-            $turns_to_process = (int)floor($minutes_since_last_update / $turn_interval_minutes);
+            $elapsed_seconds = $current_ts - $last_upd_ts;
+            if ($elapsed_seconds >= $turn_interval_minutes * 60) {
+                $turns_to_process = intdiv($elapsed_seconds, $turn_interval_minutes * 60);
+            }
         }
 
         if ($turns_to_process <= 0 && $deposits_granted <= 0) {
@@ -226,7 +227,16 @@ if ($result) {
         $bind_citizens     = (int)$gained_citizens;
         $bind_credits      = (int)$gained_credits;
         $bind_deposits     = (int)$deposits_granted;
-        $bind_now_str      = gmdate('Y-m-d H:i:s'); // same semantics as original
+        if ($last_upd_ts === false) {
+            $next_last_updated_ts = $current_ts;
+        } else {
+            $next_last_updated_ts = $last_upd_ts + ($turns_to_process * $turn_interval_minutes * 60);
+            if ($turns_to_process === 0) {
+                $next_last_updated_ts = $last_upd_ts; // preserve remainder when only deposits update
+            }
+        }
+
+        $bind_now_str      = gmdate('Y-m-d H:i:s', $next_last_updated_ts);
         $bind_deposits_ok  = (int)$deposits_granted;
         $bind_user_id      = $uid;
 

--- a/Stellar-Dominion/src/Game/TurnProcessor.php
+++ b/Stellar-Dominion/src/Game/TurnProcessor.php
@@ -159,17 +159,27 @@ if ($result) {
 
         // -------- Offline turn processing --------
         $turns_to_process = 0;
-        $last_upd_ts = strtotime($user['last_updated'] . ' UTC');
-        if ($last_upd_ts === false) {
-            write_log("WARN: bad last_updated for user {$uid}, value='{$user['last_updated']}'");
+        $seed_last_updated = false;
+        $last_upd_ts = null;
+
+        if (empty($user['last_updated'])) {
+            $seed_last_updated = true;
+            $last_upd_ts = $current_ts;
         } else {
-            $elapsed_seconds = $current_ts - $last_upd_ts;
-            if ($elapsed_seconds >= $turn_interval_minutes * 60) {
-                $turns_to_process = intdiv($elapsed_seconds, $turn_interval_minutes * 60);
+            $last_upd_ts = strtotime($user['last_updated'] . ' UTC');
+            if ($last_upd_ts === false) {
+                write_log("WARN: bad last_updated for user {$uid}, value='{$user['last_updated']}'");
+                $seed_last_updated = true;
+                $last_upd_ts = $current_ts;
+            } else {
+                $elapsed_seconds = $current_ts - $last_upd_ts;
+                if ($elapsed_seconds >= $turn_interval_minutes * 60) {
+                    $turns_to_process = intdiv($elapsed_seconds, $turn_interval_minutes * 60);
+                }
             }
         }
 
-        if ($turns_to_process <= 0 && $deposits_granted <= 0) {
+        if ($turns_to_process <= 0 && $deposits_granted <= 0 && !$seed_last_updated) {
             continue; // nothing to do for this user
         }
 
@@ -231,13 +241,12 @@ if ($result) {
         $bind_citizens     = (int)$gained_citizens;
         $bind_credits      = (int)$gained_credits;
         $bind_deposits     = (int)$deposits_granted;
-        if ($last_upd_ts === false) {
+        if ($turns_to_process > 0) {
+            $next_last_updated_ts = $last_upd_ts + ($turns_to_process * $turn_interval_minutes * 60);
+        } elseif ($seed_last_updated) {
             $next_last_updated_ts = $current_ts;
         } else {
-            $next_last_updated_ts = $last_upd_ts + ($turns_to_process * $turn_interval_minutes * 60);
-            if ($turns_to_process === 0) {
-                $next_last_updated_ts = $last_upd_ts; // preserve remainder when only deposits update
-            }
+            $next_last_updated_ts = $last_upd_ts; // preserve remainder when only deposits update
         }
 
         $bind_now_str      = gmdate('Y-m-d H:i:s', $next_last_updated_ts);


### PR DESCRIPTION
## Summary
- compute regeneration using a fresh timestamp for each player instead of a cron-wide snapshot
- advance last_updated by the number of earned turn intervals so leftover time is preserved

## Testing
- php -l Stellar-Dominion/src/Game/TurnProcessor.php

------
https://chatgpt.com/codex/tasks/task_e_68d95917d578832fad0b47788d485848